### PR TITLE
Unique Rockets mod + Multi Github asset support

### DIFF
--- a/internal/devmods.json
+++ b/internal/devmods.json
@@ -1,32 +1,32 @@
 {
-  "mods": [
-    {
-      "name": "Test Mod",
-      "blurb": "Dev testing mod",
-      "icon": "images/logos/modcirclelogos/creatorstf.svg",
-      "titleimage": "images/logos/modlogos/creatorstf.png",
-      "backgroundimage": "images/backgrounds/creatorstf.jpg",
-      "backgroundBlendMode": "luminosity",
-      "bordercolor": "green",
-      "backgroundposX": "left",
-      "backgroundposY": "top",
-      "website": "https://creators.tf",
-      "github": "",
-      "twitter": "https://creators.tf/twitter",
-      "instagram": "https://creators.tf/instagram",
-      "discord": "https://creators.tf/discord",
-      "serverlistproviders": [],
-      "isMod": false,
-      "gameId": "440",
-      "contenttext": "Test mod for development.",
-      "install": {
-        "type": "jsonlist",
-        "get_url": "https://fastdl.creators.tf/launcher/testmod.json",
-        "cloudflarebypass": true,
-        "targetdirectory": "{tf2_dir}/tf/test/",
-        "version_property_name": "Version",
-        "install_url_property_name": "DownloadLink"
-      }
-    }
-  ]
+    "mods": [
+        {
+            "name": "Test Mod",
+            "blurb": "Dev testing mod",
+            "icon": "images/logos/modcirclelogos/creatorstf.svg",
+            "titleimage": "images/logos/modlogos/creatorstf.png",
+            "backgroundimage": "images/backgrounds/creatorstf.jpg",
+            "backgroundBlendMode": "luminosity",
+            "bordercolor": "green",
+            "backgroundposX": "left",
+            "backgroundposY": "top",
+            "website": "https://creators.tf",
+            "github": "",
+            "twitter": "https://creators.tf/twitter",
+            "instagram": "https://creators.tf/instagram",
+            "discord": "https://creators.tf/discord",
+            "serverlistproviders": [],
+            "isMod": false,
+            "gameId": "440",
+            "contenttext": "Test mod for development.",
+            "install": {
+                "type": "jsonlist",
+                "get_url": "https://fastdl.creators.tf/launcher/testmod.json",
+                "cloudflarebypass": true,
+                "targetdirectory": "{tf2_dir}/tf/test/",
+                "version_property_name": "Version",
+                "install_url_property_name": "DownloadLink"
+            }
+        }
+    ]
 }

--- a/internal/mods.json
+++ b/internal/mods.json
@@ -221,6 +221,57 @@
           "asset_index": 15
         }
       ]
+    },
+    {
+        "name": "Unique Rockets",
+        "blurb": "Unique rockets for Soldiers Viewmodels",
+        "icon": "https://fastdl.creators.tf/launcher/assets/unique_rockets_icon_1.png",
+        "titleimage": "",
+        "backgroundimage": "https://fastdl.creators.tf/launcher/assets/unique_rockets_bg.jpg",
+        "backgroundBlendMode": "multiply",
+        "bordercolor": "#3E3C3F",
+        "backgroundposX": "left",
+        "backgroundposY": "top",
+        "website": "https://gamebanana.com/mods/324446",
+        "github": "https://github.com/AtomicTEM/Unique-Rockets",
+        "twitter": "",
+        "instagram": "",
+        "discord": "",
+        "serverlistproviders": [],
+        "isMod": false,
+        "gameId": "440",
+        "contenttext": "Each Rocket Launcher reloads a unique rocket that's similar to its own style.\nViewmodels only.",
+        "minLauncherVersion": "0.2.9",
+        "install": {
+            "modname": "Unique Rockets",
+            "type": "githubcollection",
+            "targetdirectory": "{tf2_dir}/tf/custom/"
+        },
+        "items": [
+            {
+                "modname": "UniqueRockets",
+                "type": "github",
+                "owner": "AtomicTEM",
+                "name": "Unique-Rockets",
+                "itemname": "base",
+                "displayname": "Base Game Rockets",
+                "targetdirectory": "{tf2_dir}/tf/custom/",
+                "asset_index": 1
+            },
+            {
+                "modname": "Unique Rockets",
+                "type": "github",
+                "owner": "AtomicTEM",
+                "name": "Unique-Rockets",
+                "itemname": "base_pluswasp",
+                "displayname": "Base + WASP Launcher",
+                "targetdirectory": "{tf2_dir}/tf/custom/",
+                "asset_index": [
+                    0,
+                    1
+                ]
+            }
+        ]
     }
   ]
 }

--- a/modules/mod_manager.ts
+++ b/modules/mod_manager.ts
@@ -1,3 +1,4 @@
+/* eslint-disable func-style */
 //Manages main functions mod installation, downloading and removal.
 import { BrowserWindow, dialog } from "electron";
 import { promises } from "fs";
@@ -161,13 +162,11 @@ class ModManager {
 
                 //Perform mod download and install.
                 try {
-                    //TS won't let me delete this bit
-                    //Args is a string. Convert it to a number
                     const desiredCollectionVersion = Utilities.FindCollectionNumber(this.source_manager.data, args);
 
                     const _url = await this.source_manager.GetFileURL(desiredCollectionVersion);
 
-                    log.log("Successfully got mod install file urls. Will proceed to try to download them.");
+                    log.verbose("Successfully got mod install file urls. Will proceed to try to download them.");
                     const result = await this.ModInstall(_url);
                     if(result){
                         //This is a function to separate the collections from the non-collections
@@ -263,7 +262,7 @@ class ModManager {
                     const data = await jsonSourceManager.GetJsonData();
 
                     const urls = [];
-                    if (data.hasOwnProperty("PatchUpdates") && data.PatchUpdates.length > 0) {
+                    if (data.PatchUpdates != null && data.PatchUpdates.length > 0) {
                         //There should be urls to patch zips for each update.
                         const patchObjects = data.PatchUpdates;
                         const patchURLS = [];
@@ -386,7 +385,7 @@ class ModManager {
         }
     }
 
-    public static async ModInstall(contentURL): Promise<boolean>{
+    public static async ModInstall(contentURL: string | Array<string>): Promise<boolean>{
         let urlArray;
         if (Array.isArray(contentURL)) {
             urlArray = contentURL;

--- a/modules/mod_sources/github_collection_source.ts
+++ b/modules/mod_sources/github_collection_source.ts
@@ -1,112 +1,15 @@
-import https from "https";
-import log from "electron-log";
-import ModInstallSource from "./mod_source_base";
-import { Install, GithubAsset } from "../mod_list_loader";
+import GithubSource from "./github_source";
 
-// Reference: https://developer.github.com/v3/repos/releases/#list-releases
+export default class GithubCollectionSource extends GithubSource {
 
-const github_api_url = "https://api.github.com/";
-
-class GithubCollectionSource extends ModInstallSource {
-    github_data = null;
-    fileType = "FILE";
-
-    constructor(install_data: Install[]) {
-        super(install_data);
-    }
-
-    //Function to get the latest github data from memory or request.
-    async _GetGithubData(): Promise<any> {
-        return new Promise((resolve, reject) => {
-            if (this.github_data != null) {
-                resolve(this.github_data);
-            } else {
-                this._GetGitHubReleaseData().then(resolve).catch(reject);
-            }
-        });
-    }
-
-    async GetLatestVersionNumber(): Promise<number> {
-        return new Promise((resolve, reject) => {
-            this._GetGithubData().then((data) => {
-                if (data.length == null || data.length == 0) {
-                    reject("No releases avaliable to download");
-                }
-
-                let date = data[0].published_at;
-                date = date.split("T")[0];
-                date = date.replace(/-/g, "");
-
-                resolve(date);
-            }).catch(reject);
-        });
-    }
-
-    async GetDisplayVersionNumber(): Promise<string> {
+    async GetFileURL(collection_version: number): Promise<string | string[]> {
         const githubData = await this._GetGithubData();
-        return `${githubData[0].tag_name}`;
-    }
-
-    async GetFileURL(collection_version: number): Promise<string> {
-        return new Promise((resolve, reject) => {
-            //Try to get the download url for the release asset.
-            this._GetGithubData().then((data) => {
-                const releaseAssets: GithubAsset[] = data[0].assets;
-                if (releaseAssets != null && releaseAssets != []) {
-                    let asset: GithubAsset;
-
-                    asset = releaseAssets[this.data[collection_version].asset_index];
-
-                    if (asset != null) {
-                        resolve(asset.browser_download_url);
-                    }
-
-                    reject("This Github repositories latest release was missing a usable asset.");
-                }
-                else reject("This Github repository has no releases avaliable.");
-            }).catch(reject);
-        });
-    }
-
-    _GetGitHubReleaseData(): Promise<string> {
-        return new Promise((resolve, reject) => {
-            //Construct initial request url to github api
-            //Use the first one
-            const url = github_api_url + `repos/${this.data[0].owner}/${this.data[0].name}/releases`;
-            log.log("Url for releases is: " + url);
-            const options = {
-                headers: {
-                    "User-Agent": "creators-tf-launcher"
-                }
-            };
-
-            const data = [];
-            //var dataLen = 0;
-
-            const req = https.get(url, options, res => {
-                console.log(`statusCode: ${res.statusCode}`);
-                res.on("data", (d) => {
-                    if (res.statusCode != 200) {
-                        reject(`Failed accessing ${url}: ` + res.statusCode);
-                        return;
-                    }
-                    data.push(d);
-                });
-
-                res.on("end", () => {
-                    const buf = Buffer.concat(data);
-                    const parsed = JSON.parse(buf.toString());
-                    resolve(parsed);
-                });
-            });
-
-            req.on("error", (error) => {
-                reject(error.toString());
-            });
-
-            req.end();
-        });
+        const releaseAssets = githubData[0].assets;
+        if (releaseAssets != null && releaseAssets != []) {
+            return this.GetFileURLs(githubData, this.data[collection_version].asset_index);
+        }
+        else {
+            throw new Error("This Github repository has no releases avaliable.");
+        }
     }
 }
-
-export default GithubCollectionSource;

--- a/modules/mod_sources/mod_source_base.ts
+++ b/modules/mod_sources/mod_source_base.ts
@@ -5,8 +5,17 @@ import isDev from "electron-is-dev";
 import Main from "../../main";
 import { Install } from "../mod_list_loader";
 import Utilities from "../utilities";
+import { dialog } from "electron";
 
-abstract class ModInstallSource {
+const filesToMove = [
+    "autoexec.cfg", "scout.cfg",
+    "soldier.cfg", "pyro.cfg",
+    "demoman.cfg", "heavyweapons.cfg",
+    "engineer.cfg", "medic.cfg",
+    "sniper.cfg", "spy.cfg"
+];
+
+export default abstract class ModInstallSource {
     data: Install[];
     fileType = "UNKNOWN";
 
@@ -15,9 +24,9 @@ abstract class ModInstallSource {
     }
     abstract GetLatestVersionNumber(): Promise<number>;
     abstract GetDisplayVersionNumber(): Promise<string>;
-    abstract GetFileURL(asset_index?: number): Promise<string>;
+    abstract GetFileURL(asset_index?: number): Promise<string | string[]>;
 
-    async PostInstall(collection_version?: string) {
+    public async PostInstall(collection_version?: string): Promise<void> {
         //Try to execute mod specific operations, like moving tf/cfg/class.cfg and tf/cfg/autoexec.cfg back to /tf/cfg/user/class.cfg
         //and /tf/cfg/user/autoexec.cfg respectively for mastercomfig
 
@@ -28,55 +37,12 @@ abstract class ModInstallSource {
 
         switch (setup_func) {
             case "movecfgs":
-                log.log("Executing movecfgs install operation");
-                const filesToMove = [
-                    "autoexec.cfg", "scout.cfg",
-                    "soldier.cfg", "pyro.cfg",
-                    "demoman.cfg", "heavyweapons.cfg",
-                    "engineer.cfg", "medic.cfg",
-                    "sniper.cfg", "spy.cfg"
-                ];
-                //Move cfgs
-                const cfgpath = path.join(Main.config.tf2_directory, "tf", "cfg");
-                const usercfgpath = path.join(cfgpath, "user");
-                log.log("cfg path is: " + cfgpath);
-                log.log("user cfg path is: \"" + usercfgpath + "\"");
-                if (!(fs.existsSync(usercfgpath))) {
-                    //Create usercfgpath
-                    log.log("user cfg path does not exist, creating...");
-                    fs.mkdirSync(usercfgpath, { recursive: true });
-                }
-                //Actually move them
-                fs.readdir(cfgpath, (err, files) => {
-                    if (err) {
-                        if (isDev) {
-                            Utilities.ErrorDialog("There was an error while trying to read folder " + cfgpath + " to move cfg files. The error was " + err, "Error");
-                        } else {
-                            Utilities.ErrorDialog("There was an error while trying to read cfg folder", "Error");
-                        }
-                        log.error("there was an error on mod_source_base.ts, line 55 when trying to read the cfg directory to move cfg files. Trying to read directory: " + cfgpath + " , the error was:" + err);
-                    }
-                    else {
-                        files.forEach(file => {
-                            log.log("Checking if should move file: " + file);
-                            if (filesToMove.indexOf(file) > -1) {
-                                log.log("Trying to move file " + path.join(cfgpath, file) + " to " + path.join(usercfgpath, path.basename(file)));
-                                fs.rename(path.join(cfgpath, file), path.join(usercfgpath, path.basename(file)), (err) => {
-                                    if (err) {
-                                        log.error("There was an error trying to move file " + path.join(cfgpath, file) + " to " + path.join(usercfgpath, path.basename(file)));
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-                break;
-            default:
+                await this.MoveCfgsInstall();
                 break;
         }
     }
 
-    async PostUninstall() {
+    public async PostUninstall(): Promise<void> {
         let setup_func: string;
         if (typeof (this.data[0]) != "undefined") {
             if ((typeof (this.data[0].setupfunc)) != "undefined") {
@@ -86,49 +52,109 @@ abstract class ModInstallSource {
 
         switch (setup_func) {
             case "movecfgs":
-                //Move them back
-                log.log("Executing movecfgs uninstall operation");
-                const filesToMove = [
-                    "autoexec.cfg", "scout.cfg",
-                    "soldier.cfg", "pyro.cfg",
-                    "demoman.cfg", "heavyweapons.cfg",
-                    "engineer.cfg", "medic.cfg",
-                    "sniper.cfg", "spy.cfg"
-                ];
-                //Move cfgs
-                const cfgpath = path.join(Main.config.tf2_directory, "tf", "cfg");
-                const usercfgpath = path.join(cfgpath, "user");
-                log.log("cfg path is: " + cfgpath);
-                log.log("user cfg path is: \"" + usercfgpath + "\"");
-                //Actually move them
-                fs.readdir(usercfgpath, (err, files) => {
-                    if (err) {
-                        if (isDev) {
-                            Utilities.ErrorDialog("There was an error while trying to read folder " + cfgpath + " to move cfg files. The error was " + err, "Error");
-                        } else {
-                            Utilities.ErrorDialog("There was an error while trying to read cfg folder", "Error");
-                        }
-                        log.error("there was an error on mod_source_base.ts, line 55 when trying to read the cfg directory to move cfg files. Trying to read directory: " + cfgpath + " , the error was:" + err);
-                    }
+                await this.MoveCfgsUninstall();
+        }
+    }
 
-                    else {
-                        files.forEach(file => {
-                            log.log("Checking if should move file: " + file);
-                            if (filesToMove.indexOf(file) > -1) {
-                                log.log("Trying to move file " + path.join(usercfgpath, file) + " to " + path.join(cfgpath, path.basename(file)));
-                                fs.rename(path.join(usercfgpath, file), path.join(cfgpath, path.basename(file)), (err) => {
-                                    if (err) {
-                                        log.error("There was an error trying to move file " + path.join(usercfgpath, file) + " to " + path.join(cfgpath, path.basename(file)));
-                                    }
-                                });
-                            }
-                        });
+    private async MoveCfgsInstall() {
+        log.log("Executing movecfgs install operation");
+        //Move cfgs
+        const cfgpath = path.join(Main.config.tf2_directory, "tf", "cfg");
+        const usercfgpath = path.join(cfgpath, "user");
+        log.log("cfg path is: " + cfgpath);
+        log.log("user cfg path is: \"" + usercfgpath + "\"");
+        if (!(fs.existsSync(usercfgpath))) {
+            //Create usercfgpath
+            log.log("user cfg path does not exist, creating...");
+            fs.mkdirSync(usercfgpath, { recursive: true });
+        }
+
+        const returnVal = await dialog.showMessageBox(Main.mainWindow, {
+            type: "info",
+            title: "Post Install Info",
+            message: "Your custom configuration files (class configs + autoexec) will now be moved from 'tf/cfg' to 'tf/cfg/user' to be loaded properly by mastercomfig. Backups will also be made in 'tf/cfg/user_backup'.\nIf you do not want your files to be moved, you can cancel this now, the mod will still be installed.",
+            buttons: ["Move Files", "Cancel"]
+        });
+
+        if(returnVal.response == 0) {
+            //Actually move them
+            const backupDir = path.join(cfgpath, "user_backup");
+            if(!fs.existsSync(backupDir)){
+                fs.mkdirSync(backupDir);
+            }
+
+            fs.readdir(cfgpath, (err, files) => {
+                if (err) {
+                    if (isDev) {
+                        Utilities.ErrorDialog("There was an error while trying to read folder " + cfgpath + " to move cfg files. The error was " + err, "Error");
+                    } else {
+                        Utilities.ErrorDialog("There was an error while trying to read cfg folder", "Error");
                     }
-                });
-                break;
-            default:
-                break;
+                    log.error("there was an error on mod_source_base.ts, line 55 when trying to read the cfg directory to move cfg files. Trying to read directory: " + cfgpath + " , the error was:" + err);
+                }
+                else {
+                    files.forEach(file => {
+                        log.log("Checking if should move file: " + file);
+                        if (filesToMove.indexOf(file) > -1) {
+                            const fullFilePath = path.join(cfgpath, file);
+                            log.log(`Will make backup copy of ${file}`);
+                            fs.copyFileSync(fullFilePath, path.join(backupDir, path.basename(file) + "_backup"));
+
+                            log.log("Trying to move file " + path.join(cfgpath, file) + " to " + path.join(usercfgpath, path.basename(file)));
+                            fs.rename(fullFilePath, path.join(usercfgpath, path.basename(file)), (err) => {
+                                if (err) {
+                                    log.error("There was an error trying to move file " + path.join(cfgpath, file) + " to " + path.join(usercfgpath, path.basename(file)));
+                                }
+                            });
+                        }
+                    });
+                }
+            });
+        }
+    }
+
+    private async MoveCfgsUninstall() {
+        //Move them back
+        log.log("Executing movecfgs uninstall operation");
+        //Move cfgs
+        const cfgpath = path.join(Main.config.tf2_directory, "tf", "cfg");
+        const usercfgpath = path.join(cfgpath, "user");
+        log.log("cfg path is: " + cfgpath);
+        log.log("user cfg path is: \"" + usercfgpath + "\"");
+
+        const returnVal = await dialog.showMessageBox(Main.mainWindow, {
+            type: "info",
+            title: "Post Uninstall Info",
+            message: "Your custom configuration files (class configs + autoexec) will now be moved from 'tf/cfg/user' back to 'tf/cfg' to work with tf2 normally again.\nIf you do not want your files to be moved, you can cancel this now.\nThe mod will still be removed.",
+            buttons: ["Move Files", "Cancel"]
+        });
+
+        if(returnVal.response == 0) {
+            //Actually move them
+            fs.readdir(usercfgpath, (err, files) => {
+                if (err) {
+                    if (isDev) {
+                        Utilities.ErrorDialog("There was an error while trying to read folder " + cfgpath + " to move cfg files. The error was " + err, "Error");
+                    } else {
+                        Utilities.ErrorDialog("There was an error while trying to read cfg folder", "Error");
+                    }
+                    log.error("there was an error on mod_source_base.ts, line 55 when trying to read the cfg directory to move cfg files. Trying to read directory: " + cfgpath + " , the error was:" + err);
+                }
+
+                else {
+                    files.forEach(file => {
+                        log.log("Checking if should move file: " + file);
+                        if (filesToMove.indexOf(file) > -1) {
+                            log.log("Trying to move file " + path.join(usercfgpath, file) + " to " + path.join(cfgpath, path.basename(file)));
+                            fs.rename(path.join(usercfgpath, file), path.join(cfgpath, path.basename(file)), (err) => {
+                                if (err) {
+                                    log.error("There was an error trying to move file " + path.join(usercfgpath, file) + " to " + path.join(cfgpath, path.basename(file)));
+                                }
+                            });
+                        }
+                    });
+                }
+            });
         }
     }
 }
-export default ModInstallSource;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "creators-tf-launcher",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "An easier way to install, update and play TF2 content.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Changed git hub source collection use inheritance like it should. Git hub collections can specify more than 1 asset id, also works for collections.
Cleaned up post install/remove tasks. Added info popups to tell user what post the post task will do, and let them skip it.
Add new unique-rockets mod.